### PR TITLE
Transaction date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem 'activesupport', '~> 5.0', '>= 5.0.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,24 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.0.7.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.1.7)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (~> 5.0, >= 5.0.0.1)
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ date || credit || debit || balance
 This program has been built in Ruby and is run via IRB in a terminal.
 
 - Clone this repo and navigate to the directory in your terminal
+- Run `bundle install`
 - Run `irb`
 - Require the bank_account file
     `require './lib/bank_account'`
@@ -81,29 +82,33 @@ As an account holder
 I want to be able to make a deposit of a specified amount
 So that I can put money into my account for safe keeping
 
-As an account holder
+As a user
 I want to be able to make a withdrawal of a specified amount
 So that I can take money from my account when I need it
 
-As an account holder
+As a user
+I want to be able to specify a transaction date in the past (canot be in the future)
+So that I can manually backdate transactions that were missed
+
+As a user
 I want to print a statement of all transactions in my account
 So that I can view the history of my deposits and withdrawals
 
-As an account holder
+As a user
 I want my statement to show a running balance with each transaction
 So that I can see what my account balance was at that time
 
-As an account holder
+As a user
 I want my statement to print the transactions in reverse chronological order
 So that I can easily follow the transactions when reading
+
+As a user
+I want all statements to have columns for date, credit, debit and balance
+So that the format is standard regardless of the transactions
 
 As a product owner
 I want to only allow amounts that are greater than 0 and up to 2 decimal places
 So that the transaction data maintains integrity
-
-As a product owner
-I want all statements to have columns for date, credit, debit and balance
-So that the format is standard regardless of the transactions
 ```
 
 * Assumption was made that an account has an overdraft and can go into a negative balance.
@@ -114,8 +119,8 @@ are made in the same day.
 
 | Objects 	    | Messages             	                |
 |------------   |------------------------------------   |
-| BankAccount 	| deposit(amount) 	                    |
-|             	| withdraw(amount)                      |
+| BankAccount 	| deposit(amount, date(optional)) 	    |
+|             	| withdraw(amount, date(optional))      |
 |            	| print_statement 	                    |
 | Statement   	| initialize(transactions)              |
 |              	| print                                 |

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ As an account holder
 I want my statement to show a running balance with each transaction
 So that I can see what my account balance was at that time
 
+As an account holder
+I want my statement to print the transactions in reverse chronological order
+So that I can easily follow the transactions when reading
+
 As a product owner
 I want to only allow amounts that are greater than 0 and up to 2 decimal places
 So that the transaction data maintains integrity
@@ -103,6 +107,8 @@ So that the format is standard regardless of the transactions
 ```
 
 * Assumption was made that an account has an overdraft and can go into a negative balance.
+* I have used a datetime on the transaction rather than just date, so ordering will handle when multiple transactions  
+are made in the same day.
 
 **Design**
 

--- a/lib/bank_account.rb
+++ b/lib/bank_account.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'active_support/core_ext/time/calculations'
 
 require_relative './transaction'
 require_relative './statement'
@@ -13,11 +14,13 @@ class BankAccount
 
   def deposit(amount, date = nil)
     validate_amount(amount)
+    validate_date(date)
     add_transaction(:credit, amount, date)
   end
 
   def withdraw(amount, date = nil)
     validate_amount(amount)
+    validate_date(date)
     add_transaction(:debit, amount, date)
   end
 
@@ -32,6 +35,12 @@ class BankAccount
     raise "Invalid amount, must be a number" unless is_a_number?(amount)
     raise "Invalid amount, must be greater than 0" unless is_greater_than_zero?(amount)
     raise "Invalid amount, can't have more than 2 decimal places" if has_over_two_decimals?(amount)
+  end
+
+  def validate_date(date)
+    if !date.nil?
+      raise "Invalid date, cannot be in the future" if Time.parse(date).future?
+    end
   end
 
   def add_transaction(type, amount, date)

--- a/lib/bank_account.rb
+++ b/lib/bank_account.rb
@@ -11,16 +11,14 @@ class BankAccount
     @transactions = []
   end
 
-  def deposit(amount)
+  def deposit(amount, date = nil)
     validate_amount(amount)
-    @transactions << @transaction_class.new(type: :credit, amount: amount, datetime: Time.now)
-    @transactions.last
+    add_transaction(:credit, amount, date)
   end
 
-  def withdraw(amount)
+  def withdraw(amount, date = nil)
     validate_amount(amount)
-    @transactions << @transaction_class.new(type: :debit, amount: amount, datetime: Time.now)
-    @transactions.last
+    add_transaction(:debit, amount, date)
   end
 
   def print_statement(transactions: @transactions, statement_class: Statement)
@@ -34,6 +32,15 @@ class BankAccount
     raise "Invalid amount, must be a number" unless is_a_number?(amount)
     raise "Invalid amount, must be greater than 0" unless is_greater_than_zero?(amount)
     raise "Invalid amount, can't have more than 2 decimal places" if has_over_two_decimals?(amount)
+  end
+
+  def add_transaction(type, amount, date)
+    @transactions << @transaction_class.new(type: type, amount: amount, datetime: datetime(date))
+    @transactions.last
+  end
+
+  def datetime(date)
+    date.nil? ? Time.now : Time.parse(date)
   end
 
   def is_a_number?(amount)

--- a/lib/statement.rb
+++ b/lib/statement.rb
@@ -18,6 +18,7 @@ class Statement
 
   def add_transactions(transactions)
     running_balance = 0
+    transactions.sort_by! { |transaction| transaction.datetime }
     formatted_transactions = transactions.map do |transaction|
       running_balance += is_credit?(transaction) ? transaction.amount : -transaction.amount
       format_transaction(transaction, running_balance)

--- a/lib/statement.rb
+++ b/lib/statement.rb
@@ -2,6 +2,7 @@ class Statement
 
   def initialize(transactions)
     @rows = []
+    @running_balance = 0
     add_header
     add_transactions(transactions)
   end
@@ -17,20 +18,23 @@ class Statement
   end
 
   def add_transactions(transactions)
-    running_balance = 0
     transactions.sort_by! { |transaction| transaction.datetime }
     formatted_transactions = transactions.map do |transaction|
-      running_balance += is_credit?(transaction) ? transaction.amount : -transaction.amount
-      format_transaction(transaction, running_balance)
+      update_balance(transaction)
+      format_transaction(transaction)
     end
     @rows << formatted_transactions.reverse
   end
 
-  def format_transaction(transaction, running_balance)
+  def update_balance(transaction)
+    @running_balance += is_credit?(transaction) ? transaction.amount : -transaction.amount
+  end
+
+  def format_transaction(transaction)
     "#{format_date(transaction.datetime)} || " +
       "#{format_amount(transaction.amount) + " " if is_credit?(transaction)}|| " +
       "#{format_amount(transaction.amount) + " " if is_debit?(transaction)}|| " +
-      "#{format_amount(running_balance)}"
+      "#{format_amount(@running_balance)}"
   end
 
   def is_credit?(transaction)

--- a/spec/features/bank_feature_spec.rb
+++ b/spec/features/bank_feature_spec.rb
@@ -42,12 +42,23 @@ describe 'Feature: Banking' do
     account = BankAccount.new
     allow(Time).to receive(:now).and_return(Time.parse("2012-01-10 10:50:15"))
     account.deposit(1000)
-    account.deposit(2000, '01/01/2011')
+    allow(Time).to receive(:now).and_return(Time.parse("2012-01-13 12:25:15"))
+    account.deposit(2000)
     allow(Time).to receive(:now).and_return(Time.parse("2012-01-14 12:25:15"))
     account.withdraw(500)
     expect{ account.print_statement }.to output(
                                            "date || credit || debit || balance\n" +
                                              "14/01/2012 || || 500.00 || 2500.00\n" +
+                                             "13/01/2012 || 2000.00 || || 3000.00\n" +
+                                             "10/01/2012 || 1000.00 || || 1000.00\n"
+                                         ).to_stdout
+
+    account.deposit(2000, '01/01/2011')
+
+    expect{ account.print_statement }.to output(
+                                           "date || credit || debit || balance\n" +
+                                             "14/01/2012 || || 500.00 || 4500.00\n" +
+                                             "13/01/2012 || 2000.00 || || 5000.00\n" +
                                              "10/01/2012 || 1000.00 || || 3000.00\n" +
                                              "01/01/2011 || 2000.00 || || 2000.00\n"
                                            ).to_stdout

--- a/spec/features/bank_feature_spec.rb
+++ b/spec/features/bank_feature_spec.rb
@@ -34,6 +34,22 @@ describe 'Feature: Banking' do
                                            "date || credit || debit || balance\n" +
                                              "14/01/2012 || || 500.00 || 2500.00\n" +
                                              "13/01/2012 || 2000.00 || || 3000.00\n" +
-                                             "10/01/2012 || 1000.00 || || 1000.00\n").to_stdout
+                                             "10/01/2012 || 1000.00 || || 1000.00\n"
+                                         ).to_stdout
+  end
+
+  it 'prints in reverse chronological order of date time, even when transaction is manually backdated' do
+    account = BankAccount.new
+    allow(Time).to receive(:now).and_return(Time.parse("2012-01-10 10:50:15"))
+    account.deposit(1000)
+    account.deposit(2000, '01/01/2011')
+    allow(Time).to receive(:now).and_return(Time.parse("2012-01-14 12:25:15"))
+    account.withdraw(500)
+    expect{ account.print_statement }.to output(
+                                           "date || credit || debit || balance\n" +
+                                             "14/01/2012 || || 500.00 || 2500.00\n" +
+                                             "10/01/2012 || 1000.00 || || 3000.00\n" +
+                                             "01/01/2011 || 2000.00 || || 2000.00\n"
+                                           ).to_stdout
   end
 end

--- a/spec/units/bank_account_spec.rb
+++ b/spec/units/bank_account_spec.rb
@@ -1,16 +1,34 @@
 require 'bank_account'
 
 describe BankAccount do
-  describe '#deposit' do
-    it 'creates a credit transaction and stores it in the account transactions' do
-      transaction_dbl = double('transaction', type: :credit)
-      transaction_class_dbl = double('transaction_class', new: transaction_dbl)
-      time_dbl = Time.parse("2020-11-02 12:25:15")
-      allow(Time).to receive(:now).and_return(time_dbl)
-      account = BankAccount.new(transaction_class: transaction_class_dbl)
 
-      expect(transaction_class_dbl).to receive(:new).once.with({amount: 50, datetime: time_dbl, type: :credit})
-      expect{ account.deposit(50) }.to change{ account.transactions.count }.by(1)
+  subject(:account) { BankAccount.new }
+
+  describe '#deposit' do
+    context 'date not specified by user' do
+      it 'creates a credit transaction and stores it in the account transactions with the current datetime' do
+        transaction_dbl = double('transaction', type: :credit)
+        transaction_class_dbl = double('transaction_class', new: transaction_dbl)
+        time_dbl = Time.parse("2020-11-02 12:25:15")
+        allow(Time).to receive(:now).and_return(time_dbl)
+        account = BankAccount.new(transaction_class: transaction_class_dbl)
+
+        expect(transaction_class_dbl).to receive(:new).once.with({amount: 50, datetime: time_dbl, type: :credit})
+        expect{ account.deposit(50) }.to change{ account.transactions.count }.by(1)
+      end
+    end
+
+    context 'date specified by user' do
+      it 'creates a credit transaction with the given date and stores it in the account transactions' do
+        transaction_dbl = double('transaction', type: :credit)
+        transaction_class_dbl = double('transaction_class', new: transaction_dbl)
+        account = BankAccount.new(transaction_class: transaction_class_dbl)
+
+        expected_date = Time.parse('01/01/2020')
+
+        expect(transaction_class_dbl).to receive(:new).once.with({amount: 50, datetime: expected_date, type: :credit})
+        expect{ account.deposit(50, '01/01/2020') }.to change{ account.transactions.count }.by(1)
+      end
     end
 
     it 'raises an error if given an amount with > 2 decimal places' do
@@ -30,15 +48,30 @@ describe BankAccount do
   end
 
   describe '#withdraw' do
-    it 'creates a debit transaction and stores it in the account transactions' do
-      transaction_dbl = double('transaction', type: :debit)
-      transaction_class_dbl = double('transaction_class', new: transaction_dbl)
-      time_dbl = Time.parse("2020-11-03 16:01:00")
-      allow(Time).to receive(:now).and_return(time_dbl)
-      account = BankAccount.new(transaction_class: transaction_class_dbl)
+    context 'date not specified by user' do
+      it 'creates a debit transaction and stores it in the account transactions with the current datetime' do
+        transaction_dbl = double('transaction', type: :debit)
+        transaction_class_dbl = double('transaction_class', new: transaction_dbl)
+        time_dbl = Time.parse("2020-11-03 16:01:00")
+        allow(Time).to receive(:now).and_return(time_dbl)
+        account = BankAccount.new(transaction_class: transaction_class_dbl)
 
-      expect(transaction_class_dbl).to receive(:new).once.with({amount: 50, datetime: time_dbl, type: :debit})
-      expect{ account.withdraw(50) }.to change{ account.transactions.count }.by(1)
+        expect(transaction_class_dbl).to receive(:new).once.with({amount: 50, datetime: time_dbl, type: :debit})
+        expect{ account.withdraw(50) }.to change{ account.transactions.count }.by(1)
+      end
+    end
+
+    context 'date specified by user' do
+      it 'creates a debit transaction with the given date and stores it in the account transactions' do
+        transaction_dbl = double('transaction', type: :credit)
+        transaction_class_dbl = double('transaction_class', new: transaction_dbl)
+        account = BankAccount.new(transaction_class: transaction_class_dbl)
+
+        expected_date = Time.parse('01/01/2020')
+
+        expect(transaction_class_dbl).to receive(:new).once.with({amount: 50, datetime: expected_date, type: :debit})
+        expect{ account.withdraw(50, '01/01/2020') }.to change{ account.transactions.count }.by(1)
+      end
     end
 
     it 'raises an error if given an amount with > 2 decimal places' do

--- a/spec/units/bank_account_spec.rb
+++ b/spec/units/bank_account_spec.rb
@@ -29,6 +29,11 @@ describe BankAccount do
         expect(transaction_class_dbl).to receive(:new).once.with({amount: 50, datetime: expected_date, type: :credit})
         expect{ account.deposit(50, '01/01/2020') }.to change{ account.transactions.count }.by(1)
       end
+
+      it 'raises an error if specified date is in the future' do
+        account = BankAccount.new
+        expect{ account.deposit(43, Date.tomorrow.to_s) }.to raise_error("Invalid date, cannot be in the future")
+      end
     end
 
     it 'raises an error if given an amount with > 2 decimal places' do

--- a/spec/units/statement_spec.rb
+++ b/spec/units/statement_spec.rb
@@ -36,17 +36,17 @@ describe Statement do
     expect{ statement.print }.to output("date || credit || debit || balance\n02/11/2020 || 12.50 || || 12.50\n").to_stdout
   end
 
-  it 'formats one transaction per line with a running balance, in reverse chronological order' do
+  it 'formats one transaction per line with a running balance, in reverse chronological order of datetime' do
     transaction_dbl_1 = TransactionDouble.new(type: :credit, amount: 20, datetime: Time.parse("2020-10-30 15:22:08"))
-    transaction_dbl_2 = TransactionDouble.new(type: :debit, amount: 12.5, datetime: Time.parse("2020-11-02 10:50:15"))
+    transaction_dbl_2 = TransactionDouble.new(type: :debit, amount: 12.5, datetime: Time.parse("2020-11-05 10:50:15"))
     transaction_dbl_3 = TransactionDouble.new(type: :credit, amount: 120.5, datetime: Time.parse("2020-11-03 08:00:15"))
     transactions = [transaction_dbl_1, transaction_dbl_2, transaction_dbl_3]
     statement = Statement.new(transactions)
 
     expect{ statement.print }.to output(
                                         "date || credit || debit || balance\n" +
-                                          "03/11/2020 || 120.50 || || 128.00\n" +
-                                          "02/11/2020 || || 12.50 || 7.50\n" +
+                                          "05/11/2020 || || 12.50 || 128.00\n" +
+                                          "03/11/2020 || 120.50 || || 140.50\n" +
                                           "30/10/2020 || 20.00 || || 20.00\n"
                                       ).to_stdout
   end


### PR DESCRIPTION
User can optionally specify transaction date:
- Deposit and withdraw methods take an optional parameter of date, defaulted to current date/time if not provided
- Date must not be in the future (activesupport gem added for the validation)
- Statement generation sorts in reverse chronological order of datetime (rather than order that they were created)